### PR TITLE
Forward slashes for read pairs

### DIFF
--- a/NGmerge.c
+++ b/NGmerge.c
@@ -152,10 +152,14 @@ void checkHeaders(char* head1, char* head2, char* header) {
       exit(error(head1, ERRHEAD));
     } else if (head1[j] == ' ')
       ok = true;  // headers match
+      else if (head1[j] == '/')
+      ok = true; // headers match, this is added for HMP data
     header[j] = head1[j];
   }
   if (header[j - 1] == ' ')
     header[j - 1] = '\0'; // removing trailing space
+  else if (header[j - 1] == '/')
+    header[j - 1] = '\0'; // removing trailing forward slash, added for HMP data
   else
     header[j] = '\0';
 }


### PR DESCRIPTION
Now handles merging read pairs where the read ID uses a forward slash to delineate between forward and reverse reads, with a /1 for forward reads and a /2 for reverse reads.